### PR TITLE
modify all function to remove output argument

### DIFF
--- a/R/di_fisheries_intensity-e2b7e6c4.R
+++ b/R/di_fisheries_intensity-e2b7e6c4.R
@@ -15,13 +15,13 @@
 #' \dontrun{
 #' di_e2b7e6c4()
 #' }
-di_e2b7e6c4 <- function(output = "data", grid = NULL, fishing_intensity_metric = 1, ...) {
+di_e2b7e6c4 <- function(grid = NULL, fishing_intensity_metric = 1, ...) {
   # Output folders and other objects used
   uid <- "e2b7e6c4"
   name <- get_shortname(uid)
   nm <- glue("{name}-{uid}")
-  exist <- check_files(uid, name, output, ondisk = FALSE)
-  path <- make_output(uid, name, output)
+  exist <- check_files(uid, name, ondisk = FALSE)
+  path <- make_output(uid, name)
 
   # WARNING: For R CMD CHECK
   Categorie <- Codes <- DA_ESP <- DF_ESP <- DL_ESP <-

--- a/R/dp_atlantic_shoreline-68609420.R
+++ b/R/dp_atlantic_shoreline-68609420.R
@@ -14,13 +14,13 @@
 #' \dontrun{
 #' dp_68609420()
 #' }
-dp_68609420 <- function(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...) {
+dp_68609420 <- function(crs = 4326, bbox = NULL, timespan = NULL, ...) {
   # Output folders and other objects used
   uid <- "68609420"
   name <- get_shortname(uid)
   nm <- glue("{name}-{uid}")
-  exist <- check_files(uid, name, output, ondisk = FALSE)
-  path <- make_output(uid, name, output)
+  exist <- check_files(uid, name, ondisk = FALSE)
+  path <- make_output(uid, name)
 
   # =~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~= #
   # DOWNLOAD DATA

--- a/R/dp_cancoast-35608fef.R
+++ b/R/dp_cancoast-35608fef.R
@@ -14,13 +14,13 @@
 #' \dontrun{
 #' dp_35608fef()
 #' }
-dp_35608fef <- function(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...) {
+dp_35608fef <- function(crs = 4326, bbox = NULL, timespan = NULL, ...) {
   # Output folders and other objects used
   uid <- "35608fef"
   name <- get_shortname(uid)
   nm <- glue("{name}-{uid}")
-  exist <- check_files(uid, name, output, ondisk = FALSE)
-  path <- make_output(uid, name, output)
+  exist <- check_files(uid, name, ondisk = FALSE)
+  path <- make_output(uid, name)
 
   # =~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~= #
   # DOWNLOAD DATA

--- a/R/dp_carms_checklist-084860fd.R
+++ b/R/dp_carms_checklist-084860fd.R
@@ -14,13 +14,13 @@
 #' \dontrun{
 #' dp_084860fd()
 #' }
-dp_084860fd <- function(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...) {
+dp_084860fd <- function(crs = 4326, bbox = NULL, timespan = NULL, ...) {
   # Output folders and other objects used
   uid <- "084860fd"
   name <- get_shortname(uid)
   nm <- glue("{name}-{uid}")
-  exist <- check_files(uid, name, output, ondisk = TRUE)
-  path <- make_output(uid, name, output)
+  exist <- check_files(uid, name, ondisk = TRUE)
+  path <- make_output(uid, name)
 
   if (!exist$clean) {
     # =~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~= #

--- a/R/dp_contaminated_sites-804db12e.R
+++ b/R/dp_contaminated_sites-804db12e.R
@@ -14,13 +14,13 @@
 #' \dontrun{
 #' dp_804db12e()
 #' }
-dp_804db12e <- function(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...) {
+dp_804db12e <- function(crs = 4326, bbox = NULL, timespan = NULL, ...) {
   # Output folders and other objects used
   uid <- "804db12e"
   name <- get_shortname(uid)
   nm <- glue("{name}-{uid}")
-  exist <- check_files(uid, name, output, ondisk = FALSE)
-  path <- make_output(uid, name, output)
+  exist <- check_files(uid, name, ondisk = FALSE)
+  path <- make_output(uid, name)
 
   # =~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~= #
   # DOWNLOAD DATA

--- a/R/dp_federal_marine_bioregions-f635934a.R
+++ b/R/dp_federal_marine_bioregions-f635934a.R
@@ -14,13 +14,13 @@
 #' \dontrun{
 #' dp_f635934a()
 #' }
-dp_f635934a <- function(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...) {
+dp_f635934a <- function(crs = 4326, bbox = NULL, timespan = NULL, ...) {
   # Output folders and other objects used
   uid <- "f635934a"
   name <- get_shortname(uid)
   nm <- glue("{name}-{uid}")
-  exist <- check_files(uid, name, output, ondisk = FALSE)
-  path <- make_output(uid, name, output)
+  exist <- check_files(uid, name, ondisk = FALSE)
+  path <- make_output(uid, name)
 
   # =~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~= #
   # DOWNLOAD DATA

--- a/R/dp_fisheries_logbooks-f2109e69.R
+++ b/R/dp_fisheries_logbooks-f2109e69.R
@@ -14,13 +14,13 @@
 #' \dontrun{
 #' dp_f2109e69()
 #' }
-dp_f2109e69 <- function(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...) {
+dp_f2109e69 <- function(crs = 4326, bbox = NULL, timespan = NULL, ...) {
   # Output folders and other objects used
   uid <- "f2109e69"
   name <- get_shortname(uid)
   nm <- glue("{name}-{uid}")
-  exist <- check_files(uid, name, output, ondisk = TRUE)
-  path <- make_output(uid, name, output)
+  exist <- check_files(uid, name, ondisk = TRUE)
+  path <- make_output(uid, name)
 
   if (!exist$clean) {
     # =~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~= #

--- a/R/dp_marine_disposal_sites-4b72884d.R
+++ b/R/dp_marine_disposal_sites-4b72884d.R
@@ -14,13 +14,13 @@
 #' \dontrun{
 #' dp_4b72884d()
 #' }
-dp_4b72884d <- function(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...) {
+dp_4b72884d <- function(crs = 4326, bbox = NULL, timespan = NULL, ...) {
   # Output folders and other objects used
   uid <- "4b72884d"
   name <- get_shortname(uid)
   nm <- glue("{name}-{uid}")
-  exist <- check_files(uid, name, output, ondisk = FALSE)
-  path <- make_output(uid, name, output)
+  exist <- check_files(uid, name, ondisk = FALSE)
+  path <- make_output(uid, name)
 
   # =~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~= #
   # DOWNLOAD DATA

--- a/R/dp_marine_seismic-06230ea3.R
+++ b/R/dp_marine_seismic-06230ea3.R
@@ -14,13 +14,13 @@
 #' \dontrun{
 #' dp_06230ea3()
 #' }
-dp_06230ea3 <- function(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...) {
+dp_06230ea3 <- function(crs = 4326, bbox = NULL, timespan = NULL, ...) {
   # Output folders and other objects used
   uid <- "06230ea3"
   name <- get_shortname(uid)
   nm <- glue("{name}-{uid}")
-  exist <- check_files(uid, name, output, ondisk = FALSE)
-  path <- make_output(uid, name, output)
+  exist <- check_files(uid, name, ondisk = FALSE)
+  path <- make_output(uid, name)
 
   # =~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~= #
   # DOWNLOAD DATA

--- a/R/dp_maritimes_grid-750b39f9.R
+++ b/R/dp_maritimes_grid-750b39f9.R
@@ -14,13 +14,13 @@
 #' \dontrun{
 #' dp_750b39f9()
 #' }
-dp_750b39f9 <- function(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...) {
+dp_750b39f9 <- function(crs = 4326, bbox = NULL, timespan = NULL, ...) {
   # Output folders and other objects used
   uid <- "750b39f9"
   name <- get_shortname(uid)
   nm <- glue("{name}-{uid}")
-  exist <- check_files(uid, name, output, ondisk = TRUE)
-  path <- make_output(uid, name, output)
+  exist <- check_files(uid, name, ondisk = TRUE)
+  path <- make_output(uid, name)
 
 
   if (!exist$clean) {

--- a/R/dp_night_lights-8509eeb1.R
+++ b/R/dp_night_lights-8509eeb1.R
@@ -14,13 +14,13 @@
 #' \dontrun{
 #' dp_8509eeb1()
 #' }
-dp_8509eeb1 <- function(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...) {
+dp_8509eeb1 <- function(crs = 4326, bbox = NULL, timespan = NULL, ...) {
   # Output folders and other objects used
   uid <- "8509eeb1"
   name <- get_shortname(uid)
   nm <- glue("{name}-{uid}")
-  exist <- check_files(uid, name, output, ondisk = TRUE)
-  path <- make_output(uid, name, output)
+  exist <- check_files(uid, name, ondisk = TRUE)
+  path <- make_output(uid, name)
 
   if (!exist$clean) {
     # =~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~= #

--- a/R/dp_shipping_gfw-8449dee0.R
+++ b/R/dp_shipping_gfw-8449dee0.R
@@ -14,13 +14,13 @@
 #' \dontrun{
 #' dp_8449dee0()
 #' }
-dp_8449dee0 <- function(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...) {
+dp_8449dee0 <- function(crs = 4326, bbox = NULL, timespan = NULL, ...) {
   # Output folders and other objects used
   uid <- "8449dee0"
   name <- get_shortname(uid)
   nm <- glue("{name}-{uid}")
-  exist <- check_files(uid, name, output, ondisk = TRUE)
-  path <- make_output(uid, name, output)
+  exist <- check_files(uid, name, ondisk = TRUE)
+  path <- make_output(uid, name)
 
   if (!exist$clean) {
     # =~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~= #

--- a/R/function_parameters.R
+++ b/R/function_parameters.R
@@ -3,7 +3,6 @@
 # NOTE: Documented here in order to avoid unnecessary repetition in documentation
 dp_params <- function() {
   c(
-    "@param output output folder for queried data. That folder will be organized into the different files that are loaded, i.e. raw data, formatted data, metadata and bibtex files. By default, data are stored in a root folder called 'data/'",
     "@param crs spatial projection to use to transform the spatial data into a uniform projection",
     "@param bbox bounding box to spatially subset the queried data, if applicable. The bounding box should be of the form `c(xmin, ymin, xmax, ymax)`",
     "@param timespan time span to temporally subset the queried data, if applicable. The time span should a vector containing all the years to be queried `c(year1, year2, ...)`",
@@ -16,7 +15,6 @@ dp_params <- function() {
 # NOTE: Documented here in order to avoid unnecessary repetition in documentation
 di_params <- function() {
   c(
-    "@param output output folder for integrated data. That folder will be organized into the different files that are loaded, i.e. raw data, formatted data, metadata and bibtex files. By default, data are stored in a root folder called 'data/'",
     "@param grid spatial grid used for data integration. Can be a `sf` object containing polygons or a `stars` rasters that will be used as a template",
     "@param ... further arguments used in individual data integration pipelines, if applicable."
   )

--- a/R/helpers_files.R
+++ b/R/helpers_files.R
@@ -3,12 +3,12 @@
 #' @importFrom crayon blue
 
 # Helper functions to manage file paths and output folders
-make_paths <- function(uid, name, output = "data") {
+make_paths <- function(uid, name) {
   paths <- list()
 
   # Output folder for clean data
   paths$clean_output <- here::here(
-    output,
+    "data",
     "data-raw",
     glue("{name}-{uid}")
   )
@@ -33,7 +33,7 @@ make_paths <- function(uid, name, output = "data") {
 
   # Output folder for integrated data
   paths$integrated_output <- here::here(
-    output,
+    "data",
     "data-integrated",
     glue("{name}-{uid}")
   )
@@ -43,9 +43,9 @@ make_paths <- function(uid, name, output = "data") {
 
 
 # Check if data is already present and send warning if data is already present and was thus not downloaded, or stop process if data needs to be available locally
-check_files <- function(uid, name, output = "data", ondisk = FALSE) {
+check_files <- function(uid, name, ondisk = FALSE) {
   # Create paths
-  paths <- make_paths(uid, name, output)
+  paths <- make_paths(uid, name)
 
   # Check if raw files exist
   exist <- list()
@@ -75,8 +75,8 @@ check_files <- function(uid, name, output = "data", ondisk = FALSE) {
 }
 
 # Check if folders exist
-check_folders <- function(uid, name, output = "data") {
-  paths <- make_paths(uid, name, output)
+check_folders <- function(uid, name) {
+  paths <- make_paths(uid, name)
   out <- list()
   out$raw <- file.exists(paths$raw_output)
   out$integrated <- file.exists(paths$integrated_output)
@@ -84,9 +84,9 @@ check_folders <- function(uid, name, output = "data") {
 }
 
 # Create output folders for data pipelines
-make_output <- function(uid, name, output = "data") {
-  paths <- make_paths(uid, name, output)
-  fold <- check_folders(uid, name, output)
+make_output <- function(uid, name) {
+  paths <- make_paths(uid, name)
+  fold <- check_folders(uid, name)
 
   # Create output folders
   type <- pipeline$pipeline_type[pipeline$pipeline_id == uid]

--- a/R/pipedat.R
+++ b/R/pipedat.R
@@ -17,7 +17,7 @@
 #' pipedat("0001")
 #' }
 #' @export
-pipedat <- function(uid, output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...) {
+pipedat <- function(uid, crs = 4326, bbox = NULL, timespan = NULL, ...) {
   # Execute data pipelines
   lapply(
     uid,
@@ -26,7 +26,6 @@ pipedat <- function(uid, output = "data", crs = 4326, bbox = NULL, timespan = NU
         glue("dp_{x}"),
         list(
           uid = uid,
-          output = output,
           crs = crs,
           bbox = bbox,
           timespan = timespan

--- a/R/pipeflow.R
+++ b/R/pipeflow.R
@@ -17,7 +17,6 @@ pipeflow <- function(config) {
   dat <- yaml::read_yaml(config)
 
   # Parameters
-  output <- dat$data_workflow$parameters$output
   crs <- dat$data_workflow$parameters$crs
   bbox_pipeline <- unlist(dat$data_workflow$parameters$bbox)
   timespan <- dat$data_workflow$parameters$timespan
@@ -28,7 +27,6 @@ pipeflow <- function(config) {
   lapply(
     dat$data_workflow$data_pipeline,
     pipedat,
-    output = output,
     crs = crs,
     bbox = bbox_pipeline,
     timespan = timespan
@@ -44,6 +42,5 @@ pipeflow <- function(config) {
   # lapply(
   #   dat$data_workflow$data_connect,
   #   pipeconnect,
-  #   output = output
   # )
 }

--- a/R/pipein.R
+++ b/R/pipein.R
@@ -15,13 +15,12 @@
 #' pipeint("0001")
 #' }
 #' @export
-pipein <- function(uid, output = "data", grid = NULL, ...) {
+pipein <- function(uid, grid = NULL, ...) {
   # Execute data integration pipelines
   do.call(
     glue("di_{uid}"),
     list(
       uid = uid,
-      output = output,
       grid = grid
     )
   )

--- a/inst/templates/data_pipeline.R
+++ b/inst/templates/data_pipeline.R
@@ -14,13 +14,13 @@
 #' \dontrun{
 #' dp_{{ dpid }}()
 #' }
-dp_{{ dpid }} <- function(output = "data",crs = 4326, bbox = NULL, timespan = NULL, ...) {
+dp_{{ dpid }} <- function(crs = 4326, bbox = NULL, timespan = NULL, ...) {
   # Output folders and other objects used
   uid <- "{{ dpid }}"
   name <- get_shortname(uid)
   nm <- glue("{name}-{uid}")
-  exist <- check_files(uid, name, output, ondisk = FALSE)
-  path <- make_output(uid, name, output)
+  exist <- check_files(uid, name, ondisk = FALSE)
+  path <- make_output(uid, name)
     
   # =~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~= #
   # DOWNLOAD DATA

--- a/inst/templates/integration_pipeline.R
+++ b/inst/templates/integration_pipeline.R
@@ -14,13 +14,13 @@
 #' \dontrun{
 #' di_{{ dpid }}()
 #' }
-di_{{ dpid }} <- function(output = "data", grid = NULL, ...) {
+di_{{ dpid }} <- function(grid = NULL, ...) {
   # Output folders and other objects used
   uid <- "{{ dpid }}"
   name <- get_shortname(uid)
   nm <- glue("{name}-{uid}")
-  exist <- check_files(uid, name, output, ondisk = FALSE)
-  path <- make_output(uid, name, output)
+  exist <- check_files(uid, name, ondisk = FALSE)
+  path <- make_output(uid, name)
 
   # =~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~=~-~= #
   # IMPORT DATA

--- a/man/data_pipelines.Rd
+++ b/man/data_pipelines.Rd
@@ -20,31 +20,29 @@
 \alias{dp_8449dee0}
 \title{Atlantic Shoreline Classification}
 \usage{
-dp_68609420(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...)
+dp_68609420(crs = 4326, bbox = NULL, timespan = NULL, ...)
 
-dp_35608fef(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...)
+dp_35608fef(crs = 4326, bbox = NULL, timespan = NULL, ...)
 
-dp_084860fd(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...)
+dp_084860fd(crs = 4326, bbox = NULL, timespan = NULL, ...)
 
-dp_804db12e(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...)
+dp_804db12e(crs = 4326, bbox = NULL, timespan = NULL, ...)
 
-dp_f635934a(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...)
+dp_f635934a(crs = 4326, bbox = NULL, timespan = NULL, ...)
 
-dp_f2109e69(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...)
+dp_f2109e69(crs = 4326, bbox = NULL, timespan = NULL, ...)
 
-dp_4b72884d(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...)
+dp_4b72884d(crs = 4326, bbox = NULL, timespan = NULL, ...)
 
-dp_06230ea3(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...)
+dp_06230ea3(crs = 4326, bbox = NULL, timespan = NULL, ...)
 
-dp_750b39f9(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...)
+dp_750b39f9(crs = 4326, bbox = NULL, timespan = NULL, ...)
 
-dp_8509eeb1(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...)
+dp_8509eeb1(crs = 4326, bbox = NULL, timespan = NULL, ...)
 
-dp_8449dee0(output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...)
+dp_8449dee0(crs = 4326, bbox = NULL, timespan = NULL, ...)
 }
 \arguments{
-\item{output}{output folder for queried data. That folder will be organized into the different files that are loaded, i.e. raw data, formatted data, metadata and bibtex files. By default, data are stored in a root folder called 'data/'}
-
 \item{crs}{spatial projection to use to transform the spatial data into a uniform projection}
 
 \item{bbox}{bounding box to spatially subset the queried data, if applicable. The bounding box should be of the form \code{c(xmin, ymin, xmax, ymax)}}

--- a/man/integration_pipelines.Rd
+++ b/man/integration_pipelines.Rd
@@ -4,11 +4,9 @@
 \alias{di_e2b7e6c4}
 \title{Fisheries intensity}
 \usage{
-di_e2b7e6c4(output = "data", grid = NULL, fishing_intensity_metric = 1, ...)
+di_e2b7e6c4(grid = NULL, fishing_intensity_metric = 1, ...)
 }
 \arguments{
-\item{output}{output folder for integrated data. That folder will be organized into the different files that are loaded, i.e. raw data, formatted data, metadata and bibtex files. By default, data are stored in a root folder called 'data/'}
-
 \item{grid}{spatial grid used for data integration. Can be a \code{sf} object containing polygons or a \code{stars} rasters that will be used as a template}
 
 \item{fishing_intensity_metric}{type of fishing intensity metric to evaluate, one of: 1: Fishing effort density, no normalization; 2: Fishing effort density; 3: Fishing biomass yield density; 4: Fishing relative biomass yield density. Passed on to eaMethods::fishing_intensity().}

--- a/man/pipedat.Rd
+++ b/man/pipedat.Rd
@@ -5,12 +5,10 @@
 \alias{pipedat}
 \title{Execute data pipelines}
 \usage{
-pipedat(uid, output = "data", crs = 4326, bbox = NULL, timespan = NULL, ...)
+pipedat(uid, crs = 4326, bbox = NULL, timespan = NULL, ...)
 }
 \arguments{
 \item{uid}{unique identifier of queried data. The full list of available data pipelines can be consulted using \code{pipelines()}}
-
-\item{output}{output folder for queried data. That folder will be organized into the different files that are loaded, i.e. raw data, formatted data, metadata and bibtex files. By default, data are stored in a root folder called 'data/'}
 
 \item{crs}{spatial projection to use to transform the spatial data into a uniform projection}
 

--- a/man/pipein.Rd
+++ b/man/pipein.Rd
@@ -4,12 +4,10 @@
 \alias{pipein}
 \title{Execute data integration pipelines}
 \usage{
-pipein(uid, output = "data", grid = NULL, ...)
+pipein(uid, grid = NULL, ...)
 }
 \arguments{
 \item{uid}{unique identifier of the data integration pipeline. The full list of available data pipelines can be consulted using \code{pipelines(type = "integrated")}}
-
-\item{output}{output folder for integrated data. That folder will be organized into the different files that are loaded, i.e. raw data, formatted data, metadata and bibtex files. By default, data are stored in a root folder called 'data/'}
 
 \item{grid}{spatial grid used for data integration. Can be a \code{sf} object containing polygons or a \code{stars} rasters that will be used as a template}
 


### PR DESCRIPTION
I initially added an argument to the functions that allowed a user to select the name of the output folder for the files downloaded and generated from the data and integration pipelines. I decided to remove that option as I found it added too much complexity uselessly in the code. Perhaps this may be revisited at some point down the line, but for now I believe it will simplify the code. 